### PR TITLE
fix: update feature branch naming regex in deployment and sync configurations

### DIFF
--- a/.base.yaml
+++ b/.base.yaml
@@ -16,8 +16,6 @@ variables:
   SSH_HOST: ${SSH_HOST_STAGE}
   SSH_PORT_DEFAULT: 22
   SSH_PORT: ${SSH_PORT_DEFAULT}
-  # Override this regex to match your feature branch naming convention
-  FEATURE_BRANCH_NAME_REGEX: '^JIRA-.*$'
 
 #-----------------------------------------------------------------------------------------------------------------------
 # STAGES

--- a/deploy/deploy-feature-cleanup.yaml
+++ b/deploy/deploy-feature-cleanup.yaml
@@ -12,7 +12,7 @@ deploy:feature:cleanup:
       when: never
     - if: $CI_PIPELINE_SOURCE == "pipeline"
       when: never
-    - if: $CI_COMMIT_REF_NAME =~ /$FEATURE_BRANCH_NAME_REGEX/
+    - if: $CI_COMMIT_REF_NAME =~ /^[A-Z]{2,}-\d+-.*$/
       when: manual
     - if: $CI_COMMIT_REF_NAME =~ /^feature-.*$/
       when: manual

--- a/deploy/deploy-feature-rollback.yaml
+++ b/deploy/deploy-feature-rollback.yaml
@@ -15,7 +15,7 @@ deploy:feature:rollback:
       when: never
     - if: $CI_PIPELINE_SOURCE == "pipeline"
       when: never
-    - if: $CI_COMMIT_REF_NAME =~ /$FEATURE_BRANCH_NAME_REGEX/
+    - if: $CI_COMMIT_REF_NAME =~ /^[A-Z]{2,}-\d+-.*$/
     - if: $CI_COMMIT_REF_NAME =~ /^feature-.*$/
     - if: $CI_COMMIT_REF_NAME == "main"
   variables:

--- a/deploy/deploy-feature.yaml
+++ b/deploy/deploy-feature.yaml
@@ -15,7 +15,7 @@ deploy:feature:
       when: never
     - if: $CI_COMMIT_TAG
       when: never
-    - if: $CI_COMMIT_REF_NAME =~ /$FEATURE_BRANCH_NAME_REGEX/
+    - if: $CI_COMMIT_REF_NAME =~ /^[A-Z]{2,}-\d+-.*$/
     - if: $CI_COMMIT_REF_NAME =~ /^feature-.*$/
     - if: $CI_COMMIT_REF_NAME == "main"
   resource_group: $CI_COMMIT_REF_NAME

--- a/sync/sync-feature.yaml
+++ b/sync/sync-feature.yaml
@@ -26,7 +26,7 @@ sync:feature:
       when: never
     - if: $CI_PIPELINE_SOURCE == "pipeline"
       when: never
-    - if: $CI_COMMIT_REF_NAME =~ /$FEATURE_BRANCH_NAME_REGEX/
+    - if: $CI_COMMIT_REF_NAME =~ /^[A-Z]{2,}-\d+-.*$/
       when: manual
     - if: $CI_COMMIT_REF_NAME =~ /^feature-.*$/
       when: manual

--- a/test/test-feature-codeception.yaml
+++ b/test/test-feature-codeception.yaml
@@ -16,7 +16,7 @@ test:feature:codeception:
       when: never
     - if: $CI_COMMIT_TAG
       when: never
-    - if: $CI_COMMIT_REF_NAME =~ /$FEATURE_BRANCH_NAME_REGEX/
+    - if: $CI_COMMIT_REF_NAME =~ /^[A-Z]{2,}-\d+-.*$/
     - if: $CI_COMMIT_REF_NAME =~ /^feature-.*$/
     - if: $CI_COMMIT_REF_NAME == "main"
   variables:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch name matching rules in deployment, sync, and test jobs to use a standardized, stricter pattern for feature branch names.
  * Removed the configurable environment variable for branch name regex, simplifying configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->