### PR TITLE
fix: set expiration for artifacts in linting and release notes configurations

### DIFF
--- a/analyze/analyze-js-lint.yaml
+++ b/analyze/analyze-js-lint.yaml
@@ -16,6 +16,7 @@ analyze:js:lint:
     reports: { }
     paths:
       - node_modules/
+    expire_in: 1 day
   script:
     - npm run lint:js
   rules:

--- a/analyze/analyze-style-lint.yaml
+++ b/analyze/analyze-style-lint.yaml
@@ -16,6 +16,7 @@ analyze:style:lint:
     reports: { }
     paths:
       - node_modules/
+    expire_in: 1 day
   script:
     - npm run lint:style
   rules:

--- a/build/build-release-notes.yaml
+++ b/build/build-release-notes.yaml
@@ -18,3 +18,4 @@ build:release-notes:
   artifacts:
     paths:
       - release_notes.md
+    expire_in: 1 day


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Set artifacts from linting and release notes jobs to expire automatically after one day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->