### PR TITLE
feat: add ci linting template for content blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use `include` to reference template files:
 include:
    - 'https://raw.githubusercontent.com/move-elevator/gitlab-ci-templates/main/.base.yml'
    - 'https://raw.githubusercontent.com/move-elevator/gitlab-ci-templates/main/build/build-php.yml'
-   - ... 
+   - ...
 ```
 
 Extend and override configuration variables, see [.base.yaml](.base.yaml) for predefined variables.
@@ -49,6 +49,7 @@ Analyze code quality and static analysis.
 
 Includes:
 - `analyze/analyze-composer-lint.yaml`
+- `analyze/analyze-content-blocks-lint.yaml`
 - `analyze/analyze-editorconfig.yaml`
 - `analyze/analyze-js-lint.yaml`
 - `analyze/analyze-php-cs-fixer.yaml`
@@ -64,7 +65,7 @@ Includes:
 
 ### Feature Branch Deployment
 
-Deploy feature branches to a dedicated environment. 
+Deploy feature branches to a dedicated environment.
 
 The deployment uses [deployer](https://deployer.org/) and [deployer-tools](https://github.com/move-elevator/deployer-tools) as deployment base.
 
@@ -97,7 +98,7 @@ Includes:
 - `deploy/deploy-stage.yaml`
 
 > [!NOTE]
-> Use this template if the project wants a simple stage deployment and doesn't need an advanced feature branch deployment. 
+> Use this template if the project wants a simple stage deployment and doesn't need an advanced feature branch deployment.
 
 ### Release
 

--- a/analyze/analyze-content-blocks-lint.yaml
+++ b/analyze/analyze-content-blocks-lint.yaml
@@ -1,0 +1,22 @@
+# Purpose:
+#   Analyze job for simply linting all content block config files
+#
+# Dependency:
+#   Composer package "friendsoftypo3/content-blocks" and a composer script "lint:content-blocks"
+#
+analyze:content-blocks:lint:
+  image:
+    name: ${DEFAULT_IMAGE_BUILD_COMPOSER}
+  stage: analyze
+  needs:
+    - build:php
+  script:
+    - composer run lint:content-blocks
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: always
+    - if: $CI_COMMIT_TAG || $CI_PIPELINE_SOURCE == "schedule" || $CI_PIPELINE_SOURCE == "pipeline" || $CI_PIPELINE_SOURCE == "merge_request_event"
+      when: never
+    - if: $CI_COMMIT_TAG == null
+      changes:
+        - "**/ContentBlocks/**/*.yaml"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated content-blocks linting to the CI analysis stage — validates content block YAML changes earlier in the pipeline.
* **Documentation**
  * Cleaned up README formatting and examples and added a reference to the new analysis template for content-blocks validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->