### PR TITLE
feat: auto-trigger prod deployment on semver tags

### DIFF
--- a/deploy/deploy-prod.yaml
+++ b/deploy/deploy-prod.yaml
@@ -20,6 +20,6 @@ deploy:prod:
     - if: $CI_PIPELINE_SOURCE == "pipeline"
       when: never
     - if: $CI_COMMIT_TAG =~ /^v?\d+\.\d+\.\d+$/
-      when: manual
+      when: always
     - when: never
   allow_failure: false


### PR DESCRIPTION
## Summary

- Change prod deployment from manual to automatic trigger on semver tags (`v1.2.3` or `1.2.3`)

## Changes

- `deploy/deploy-prod.yaml` - Switch `when: manual` to `when: always` for semver tag rule