### PR TITLE
docs: add note for TYPO3 <14 content blocks lint job

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Analyze code quality and static analysis.
 
 Includes:
 - `analyze/analyze-composer-lint.yaml`
-- `analyze/analyze-content-blocks-lint.yaml`
+- `analyze/analyze-content-blocks-lint.yaml` (**Note:** TYPO3 <14 requires an active database connection for the lint command)
 - `analyze/analyze-editorconfig.yaml`
 - `analyze/analyze-fluid-lint.yaml`
 - `analyze/analyze-js-lint.yaml`

--- a/analyze/analyze-content-blocks-lint.yaml
+++ b/analyze/analyze-content-blocks-lint.yaml
@@ -4,6 +4,10 @@
 # Dependency:
 #   Composer package "friendsoftypo3/content-blocks" and a composer script "lint:content-blocks"
 #
+# Note:
+#   TYPO3 <14 requires an active database connection for the lint command.
+#   Make sure a database service is available in the CI job when using TYPO3 <14.
+#
 analyze:content-blocks:lint:
   image:
     name: ${DEFAULT_IMAGE_BUILD_COMPOSER}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification that TYPO3 versions below 14 require an active database connection when running lint operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->