### PR TITLE
fix: add default SSH port for prod deployments

### DIFF
--- a/.base.yaml
+++ b/.base.yaml
@@ -15,6 +15,7 @@ variables:
   SSH_USER: ${SSH_USER_STAGE}
   SSH_HOST: ${SSH_HOST_STAGE}
   SSH_PORT_STAGE: 22
+  SSH_PORT_PROD: 22
   SSH_PORT: ${SSH_PORT_STAGE}
 
 #-----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add missing `SSH_PORT_PROD` default to the base configuration so production deployments have a working SSH port out of the box

## Background

Commit `16353cd` introduced `SSH_PORT: ${SSH_PORT_PROD}` in the prod deploy and rollback jobs, but `.base.yaml` only defined a default for stage (`SSH_PORT_STAGE: 22`). As a result, production deployments had no default SSH port unless the consuming project set `SSH_PORT_PROD` explicitly.

## Changes

- `.base.yaml` - Add `SSH_PORT_PROD: 22` default, mirroring the existing stage default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to include a production SSH port setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->